### PR TITLE
chore: add blueprint to configure hoot-at service on Render

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,16 @@
+# Configures the hoot-at service in Render.
+
+services:
+  - name: hoot-at
+    type: web
+    runtime: node
+    buildCommand: npm ci
+    startCommand: npm start
+    region: oregon
+    # Starter plan includes ½ CPU and 512 MB memory, and costs $7 per month
+    plan: starter
+    numInstances: 1
+    domains:
+      - hoot.at
+      - api.hoot.at
+    autoDeploy: true  # Deploys from `master`, where the Render Blueprint syncs from


### PR DESCRIPTION
| 🚥 Resolves INFRA-136 |
| :------------------- |

## 🧰 Changes

Creates a blueprint to configure the `hoot-at` service on Render. [More info](https://render.com/docs/blueprint-spec)

Once this is merged I'll deploy it to Render, launch the service and verify that it works, and then update the DNS for `hoot.at` and `api.hoot.at`.